### PR TITLE
Get and process Myo data outside open_myo module

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,26 @@
 import open_myo as myo
 
+def process_emg(emg):
+    print(emg)
+
+def process_imu(quat, acc, gyro):
+    print(quat)
+
+def process_sync(arm, x_direction):
+    print(arm, x_direction)
+
+def process_classifier(pose):
+    print(pose)
+
+def process_battery(batt):
+    print("Battery level: %d" % batt)
+
+def led_emg(emg):
+    if(emg[0] > 80):
+        myo_device.services.set_leds([255, 0, 0], [128, 128, 255])
+    else:
+        myo_device.services.set_leds([128, 128, 255], [128, 128, 255])
+
 myo_mac_addr = myo.get_myo()
 print("MAC address: %s" % myo_mac_addr)
 myo_device = myo.Device()
@@ -16,6 +37,12 @@ myo_device.services.imu_notifications()
 myo_device.services.classifier_notifications()
 # myo_device.services.battery_notifications()
 myo_device.services.set_mode(myo.EmgMode.FILT, myo.ImuMode.DATA, myo.ClassifierMode.ON)
+myo_device.add_emg_event_handler(process_emg)
+myo_device.add_emg_event_handler(led_emg)
+# myo_device.add_imu_event_handler(process_imu)
+myo_device.add_sync_event_handler(process_sync)
+# myo_device.add_classifier_event_hanlder(process_classifier)
+
 while True:
     if myo_device.services.waitForNotifications(1):
         continue


### PR DESCRIPTION
By using event handlers (callback functions that are executed when a certain event happens), data coming from the Myo (EMG, IMU, poses...) can be processed outside the open_myo module. In addition, more than one event handler can be associated to an event (for example, more than one function can be executed when new EMG data is available).